### PR TITLE
Add route to create Jios

### DIFF
--- a/backend/src/controllers/JioController.ts
+++ b/backend/src/controllers/JioController.ts
@@ -1,0 +1,20 @@
+import { Request, Response } from "express";
+import { JioCreator } from "../services/jio";
+import { SuccessId } from "src/types/errors";
+import { JioPostData } from "src/types/jios";
+
+export async function create(
+  request: Request<{}, any, JioPostData, any>,
+  response: Response<SuccessId>
+): Promise<void> {
+  try {
+    const jio = await new JioCreator().createJio(request.body);
+
+    response.status(200).json({ success: true, id: jio.id });
+    return;
+  } catch (e) {
+    console.log(e);
+    response.status(400).json({ success: false });
+    return;
+  }
+}

--- a/backend/src/routes/api/index.ts
+++ b/backend/src/routes/api/index.ts
@@ -1,10 +1,12 @@
 import { Router } from "express";
 import auth from "./auth";
 import users from "./users";
+import jios from "./jios";
 
 const routes = Router();
 
 routes.use("/auth", auth);
 routes.use("/users", users);
+routes.use("/jios", jios);
 
 export default routes;

--- a/backend/src/routes/api/jios.ts
+++ b/backend/src/routes/api/jios.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import * as JioController from "../../controllers/JioController";
+import { checkBearerToken } from "../../middlewares/checkBearerToken";
+import { BearerTokenType } from "../../types/tokens";
+
+export const router = Router();
+
+// router.use(checkBearerToken(BearerTokenType.AccessToken));
+router.post("/create", JioController.create);
+
+export default router;

--- a/backend/src/services/jio/index.ts
+++ b/backend/src/services/jio/index.ts
@@ -1,0 +1,1 @@
+export { JioCreator } from "./jio";

--- a/backend/src/services/jio/jio.ts
+++ b/backend/src/services/jio/jio.ts
@@ -1,0 +1,32 @@
+import { validate } from "class-validator";
+import { Jio } from "../../entities/Jio";
+import { JIO_CREATOR_ERROR } from "../../types/errors";
+import { JioPostData } from "../../types/jios";
+import { getRepository } from "typeorm";
+
+class JioCreatorError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = JIO_CREATOR_ERROR;
+  }
+}
+
+export class JioCreator {
+  public async createJio(createData: JioPostData): Promise<Jio> {
+    const { name, closeAt, paymentNumber, user, orderLimit } = createData;
+
+    let jio: Jio = new Jio(name, closeAt, paymentNumber, user, orderLimit);
+    const errors = await validate(jio);
+    if (errors.length > 0) {
+      throw new JioCreatorError(
+        `Provided Jio details (name: ${name}, closeAt: ${closeAt}) ` +
+          `failed validation checks (failed properties: ${errors.map(
+            (e) => e.property
+          )})`
+      );
+    }
+
+    jio = await getRepository(Jio).save(jio);
+    return jio;
+  }
+}

--- a/backend/src/types/errors.ts
+++ b/backend/src/types/errors.ts
@@ -1,0 +1,12 @@
+export interface Message {
+  message: string;
+}
+
+export interface SuccessId {
+  success: boolean;
+  id?: number;
+}
+
+export const TYPEORM_ENTITYNOTFOUND = "EntityNotFound";
+
+export const JIO_CREATOR_ERROR = "JioCreatorError";


### PR DESCRIPTION
Add API routes for the creation of Jios.

Changes:
- Create JioController with create method
- Add JioCreator to services
- Add /jio/create to routes
- Add error interface